### PR TITLE
docs: improve README with full repo documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,110 @@
-# OMG, Dertfiles
+# Dertfiles
 
-My personal extensions to thoughtbot's
-[laptop](https://github.com/thoughtbot/laptop) and
-[dotfiles](https://github.com/thoughtbot/dotfiles).
+Personal dotfiles that extend thoughtbot's [laptop](https://github.com/thoughtbot/laptop) and [dotfiles](https://github.com/thoughtbot/dotfiles). Everything here is the `*.local` overlay — thoughtbot's dotfiles source these automatically via their `rcm` setup.
 
-### Installation
+## Repository structure
+
 ```
+.
+├── .laptop.local           # Laptop script extensions (brews, casks, asdf plugins, macOS defaults)
+├── install.sh              # Codespaces bootstrap (auto-detected via $CODESPACES)
+├── install-copilot.sh      # Symlinks copilot/ configs into ~/.copilot/
+├── install-gh-extensions.sh# Installs gh CLI extensions (idempotent)
+│
+├── aliases.local           # Shell aliases (Rails, Heroku, Ruby, Git)
+├── gitconfig.local         # Git identity, aliases, editor, diff tool
+├── git_template.local/     # Git hooks (commit, pre-commit, prepare-commit-message)
+├── zshrc.local             # Zsh prompt, history, PATH, plugins (fzf, fzf-tab, z, asdf)
+├── zshenv.local            # (empty — reserved for env vars loaded before .zshrc)
+├── tmux.conf.local         # Tmux: rebinds prefix to C-a
+│
+├── vimrc.local             # Vim settings, keybindings, plugin config (NERDTree, FZF, Fugitive, ALE)
+├── vimrc.bundles.local     # vim-plug plugins (NeoSolarized, fzf, Copilot, vim-plan, etc.)
+├── nvim.local              # Neovim init — sources ~/.vimrc then loads Lua plugins
+├── nvim/lua/               # Neovim Lua plugin configs (packer)
+│
+├── copilot/                # GitHub Copilot CLI configs (see copilot/README.md)
+├── gemrc.local             # Gem defaults (skip ri/rdoc)
+├── ripgreprc               # Ripgrep defaults (smart-case, max-columns, glob exclusions)
+└── codespaces.local        # Codespaces-specific setup (linuxbrew, fzf, nvim, ctags)
+```
+
+## Fresh machine setup
+
+```bash
+# 1. Run thoughtbot's laptop script
 curl --remote-name https://raw.githubusercontent.com/thoughtbot/laptop/master/mac
 curl --remote-name https://raw.githubusercontent.com/maxbeizer/dertfiles/master/.laptop.local
 less mac
 sh mac 2>&1 | tee ~/laptop.log
+
+# 2. Link Copilot CLI configs
+./install-copilot.sh
+
+# 3. Install gh CLI extensions
+./install-gh-extensions.sh
 ```
+
+`.laptop.local` handles Homebrew packages, cask apps, Ruby gems, asdf language plugins, fzf setup, ripgrep config, and macOS keyboard repeat settings.
+
+## Codespaces
+
+When `$CODESPACES` is set, `install.sh` runs automatically and:
+
+- Symlinks local dotfiles into `$HOME`
+- Downloads thoughtbot base dotfiles
+- Installs vim-plug plugins
+- Sets up Neovim with packer
+- Configures bash with aliases, editor, and Go/Copilot paths
+
+## Key aliases
+
+| Alias | Command |
+|-------|---------|
+| `gs` | `git status -b -s` |
+| `dm` | `bin/rails db:migrate` |
+| `rc` | `bin/rails c` |
+| `be` | `bundle exec` |
+| `h` | `heroku` |
+| `speedtest` | `networkQuality` |
+
+See `aliases.local` for the full list.
+
+## Git aliases
+
+Defined in `gitconfig.local`. Highlights:
+
+| Alias | Description |
+|-------|-------------|
+| `git lg` | Pretty log graph |
+| `git ap` | `add -p` (interactive staging) |
+| `git syncm` | Checkout main, pull, rebase current branch |
+| `git fwl` | `push --force-with-lease` |
+| `git standup` | Yesterday's commits by you |
+| `git brr` | Checkout recent branch via fzf |
+| `git cleanupm` | Delete branches merged into main |
+
+## Vim / Neovim
+
+- **Leader**: `,`
+- **Colorscheme**: NeoSolarized (dark)
+- **File finder**: fzf (`Ctrl-P` files, `Ctrl-T` buffers)
+- **File tree**: NERDTree (`Ctrl-N`)
+- **Git**: Fugitive (`<leader>gs`, `<leader>gd`, etc.)
+- **Debugger shortcuts**: `<leader>b` inserts `binding.pry`, `<leader>i` inserts `IEx.pry`
+- Strips trailing whitespace on save for `.rb`, `.ex`, `.exs`, `.js`
+
+Plugins are managed by vim-plug in `vimrc.bundles.local`.
+
+## Copilot CLI
+
+See [`copilot/README.md`](copilot/README.md) for Copilot CLI config, MCP servers, and skills setup.
+
+## Dependencies
+
+- [thoughtbot/laptop](https://github.com/thoughtbot/laptop) — base setup script
+- [thoughtbot/dotfiles](https://github.com/thoughtbot/dotfiles) — base dotfiles (sourced via rcm)
+- [asdf](https://asdf-vm.com/) — runtime version manager (Ruby, Erlang, Elixir, Go, Node.js)
+- [fzf](https://github.com/junegunn/fzf) — fuzzy finder
+- [fzf-tab](https://github.com/Aloxaf/fzf-tab) — fzf-powered zsh tab completion (cloned to `~/code/fzf-tab`)
+- [z](https://github.com/rupa/z) — directory jumper (sourced from `~/z.sh`)


### PR DESCRIPTION
## What

Replaces the minimal README with comprehensive documentation covering:

- **Repository structure** — annotated tree of every file and directory
- **Fresh machine setup** — step-by-step instructions (laptop script, Copilot CLI, gh extensions)
- **Codespaces bootstrap** — what `install.sh` does when `$CODESPACES` is set
- **Alias reference tables** — quick-lookup for shell and git aliases
- **Vim/Neovim summary** — leader key, colorscheme, key bindings, plugin highlights
- **Dependencies** — links to all external tools (thoughtbot dotfiles, asdf, fzf, z, fzf-tab)

## Why

The old README only had the initial laptop install command. This makes it easier to onboard onto a new machine, understand what each file does, and find aliases/keybindings without reading every config file.